### PR TITLE
Add python script and cli to read values

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "firmware/lib/harp.core.rp2040"]
 	path = firmware/lib/harp.core.rp2040
-	url = git@github.com:AllenNeuralDynamics/harp.core.rp2040.git
+	url = git@github.com:AllenNeuralDynamics/harp.core.pico.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "firmware/lib/harp.core.rp2040"]
 	path = firmware/lib/harp.core.rp2040
-	url = git@github.com:AllenNeuralDynamics/harp.core.pico.git
+	url = https://github.com/AllenNeuralDynamics/harp.core.pico.git

--- a/software/python/README.md
+++ b/software/python/README.md
@@ -4,7 +4,7 @@ Contains a small package to interface with the environment sensor device, and a 
 
 ## Installation
 
-`pip install "git+https://github.com/AllenNeuralDynamics/harp.device.environment-sensor.git@feat-add-python-script#egg=harp_env_sensor&subdirectory=software/python"`
+`pip install "git+https://github.com/AllenNeuralDynamics/harp.device.environment-sensor.git@feat-add-python-script#egg=harp_env_sensor&subdirectory=software/python" --force-reinstall`
 
 If you're on a SIPE computer with the default pip environment variables set to the devpi server, you'll need to add `-i https://pypi.org/simple` after the pip install above.
 
@@ -17,6 +17,7 @@ CLI Arguments:
     - `events`: Polls events as they come in and print to terminal and file if provided
     - `continuous`: Reads registers every 1.5 seconds and print to terminal and file if provided
 - `--file` Path to file to write output to. Optional.
+- `--device-yaml` Path to device yaml file. Optional, defaults to hardcoded values
 
 Examples:
 

--- a/software/python/README.md
+++ b/software/python/README.md
@@ -15,9 +15,10 @@ CLI Arguments:
 - `--mode` Read mode
     - `single`: Takes one reading, prints it to terminal, and exits
     - `events`: Polls events as they come in and print to terminal and file if provided
-    - `continuous`: Reads registers every 1.5 seconds and print to terminal and file if provided
+    - `continuous`: Reads registers every <update_interval_s> seconds and print to terminal and file if provided
 - `--file` Path to file to write output to. Optional.
 - `--device-yaml` Path to device yaml file. Optional, defaults to hardcoded values
+- `--update_interval_s` If in continuous mode, read registers with this period. Optional, defaults 1.5
 
 Examples:
 
@@ -28,3 +29,7 @@ Examples:
 - Read the registers regularly and print to terminal
 
     `python -m harp_env_sensor.main --comport COM8 --mode continuous`
+  
+- Read the registers every 5 s and print to terminal
+
+    `python -m harp_env_sensor.main --comport COM8 --mode continuous --update_interval_s 5`

--- a/software/python/README.md
+++ b/software/python/README.md
@@ -6,6 +6,8 @@ Contains a small package to interface with the environment sensor device, and a 
 
 `pip install "git+https://github.com/AllenNeuralDynamics/harp.device.environment-sensor.git@feat-add-python-script#egg=harp_env_sensor&subdirectory=software/python"`
 
+If you're on a SIPE computer with the default pip environment variables set to the devpi server, you'll need to add `-i https://pypi.org/simple` after the pip install above.
+
 ## Usage
 
 CLI Arguments:

--- a/software/python/README.md
+++ b/software/python/README.md
@@ -1,0 +1,27 @@
+# Python drivers for the environment sensor
+
+Contains a small package to interface with the environment sensor device, and a script runnable with `python -m harp_env_sensor.main` to read the data and optionally save it to a csv file.
+
+## Installation
+
+`pip install "git+https://github.com/AllenNeuralDynamics/harp.device.environment-sensor.git@feat-add-python-script#egg=harp_env_sensor&subdirectory=software/python"`
+
+## Usage
+
+CLI Arguments:
+- `--comport` Port name where the device is connected. Optional. If missing, it'll list available ports and prompt.
+- `--mode` Read mode
+    - `single`: Takes one reading, prints it to terminal, and exits
+    - `events`: Polls events as they come in and print to terminal and file if provided
+    - `continuous`: Reads registers every 1.5 seconds and print to terminal and file if provided
+- `--file` Path to file to write output to. Optional.
+
+Examples:
+
+- Read events from COM8 and save to file
+
+    `python -m harp_env_sensor.main --comport COM8 --mode events --file ./output.csv`
+
+- Read the registers regularly and print to terminal
+
+    `python -m harp_env_sensor.main --comport COM8 --mode continuous`

--- a/software/python/pyproject.toml
+++ b/software/python/pyproject.toml
@@ -18,8 +18,7 @@ dynamic = ["version"]
 
 dependencies = [
     'pyyaml',
-    'pyharp@git+https://github.com/AllenNeuralDynamics/pyharp.git@368e346dd66c17516974a339a0cf3f4807c02874',
-    'pyserial',
+    "pyharp@git+https://github.com/AllenNeuralDynamics/pyharp.git@7281aca2be6cfee76c6c4c11b7f767b29d490c32",
 ]
 
 [project.optional-dependencies]

--- a/software/python/pyproject.toml
+++ b/software/python/pyproject.toml
@@ -18,7 +18,7 @@ dynamic = ["version"]
 
 dependencies = [
     'pyyaml',
-    'pyharp',
+    'pyharp@git+https://github.com/AllenNeuralDynamics/pyharp.git@368e346dd66c17516974a339a0cf3f4807c02874',
     'pyserial',
 ]
 

--- a/software/python/src/harp_env_sensor/main.py
+++ b/software/python/src/harp_env_sensor/main.py
@@ -76,7 +76,7 @@ def read_once(device: EnvSensorDevice) -> tuple[float, float, float]:
     return pressure, temp, humidity
 
 
-def read_continuously(device: EnvSensorDevice, file: Optional[Path] = None):
+def read_continuously(device: EnvSensorDevice, file: Optional[Path] = None,update_interval_s:float = 1.5):
     with contextlib.ExitStack() as stack:
         f = stack.enter_context(open(file, "w")) if file is not None else None
         if f is not None:
@@ -86,7 +86,7 @@ def read_continuously(device: EnvSensorDevice, file: Optional[Path] = None):
             press, temp, hum = read_once(device)
             if f is not None:
                 f.write(f"{time.time()}, {press}, {temp}, {hum}\n")
-            time.sleep(1.5)
+            time.sleep(update_interval_s)
 
 
 def read_events(device: EnvSensorDevice, file: Optional[Path] = None):
@@ -116,6 +116,7 @@ def cli() -> argparse.Namespace:
     parser.add_argument("--comport", type=str, help="Serial port where the device is connected", default=None)
     parser.add_argument("--file", type=os.path.abspath)
     parser.add_argument("--mode", choices=["single", "continuous", "events"], default="single")
+    parser.add_argument("--update_interval_s", type=float, default=1.5)
     args = parser.parse_args(sys.argv[1:])
 
     return args
@@ -151,6 +152,6 @@ if __name__ == "__main__":
     if args.mode == "single":
         read_once(device)
     elif args.mode == "continuous":
-        read_continuously(device, args.file)
+        read_continuously(device, args.file, args.update_interval_s)
     elif args.mode == "events":
         read_events(device, args.file)

--- a/software/python/src/harp_env_sensor/main.py
+++ b/software/python/src/harp_env_sensor/main.py
@@ -1,36 +1,96 @@
+import argparse
+import contextlib
+import os
 from pathlib import Path
-import yaml
+from serial.tools import list_ports
+import sys
 import time
+from typing import Optional
+import yaml
 
+from pyharp.messages import ReplyHarpMessage
 from pyharp.device import DeviceMode, Device
 
-from harp_env_sensor import EnvSensorDevice
-
-com_port = "COM4"
-
-device_yaml_path = Path(__file__).parents[4] / "device.yml"
-with open(device_yaml_path, "r") as file:
-    device_yaml = yaml.safe_load(file)
+from harp_env_sensor import EnvSensorDevice, __version__
 
 
-config_dict = {
-    "dump_file_path": str(Path(__file__).parent),
-    "device_configuration": yaml.safe_load(device_yaml),
-}
-
-device = EnvSensorDevice(com_port, config_dict)
-# device = Device(com_port)
-
-
-device.set_mode(DeviceMode.Active)
-while True:
-    print(f"Pressure: {device.Pressure}, Temperature: {device.Temperature}, Humidity: {device.Humidity}")
-    time.sleep(1.5)
-
-    # event_response = device._read()  # read any incoming events.
-    # if event_response is not None:  # and event_response.address != 44:
-    #     print()
-    #     print(event_response)
+def read_once(device: EnvSensorDevice) -> tuple[float, float, float]:
+    pressure = device.Pressure[0]
+    temp = device.Temperature[0]
+    humidity = device.Humidity[0]
+    print(f"Pressure (Pa): {pressure}, Temperature (C): {temp}, Humidity (prh): {humidity}")
+    return pressure, temp, humidity
 
 
-pass
+def read_continuously(device: EnvSensorDevice, file: Optional[Path] = None):
+    with contextlib.ExitStack() as stack:
+        f = stack.enter_context(open(file, "w")) if file is not None else None
+        if f is not None:
+            f.write("Timestamp, Pressure_Pa, Temperature_C, Humidity_prh\n")
+
+        while True:
+            press, temp, hum = read_once(device)
+            if f is not None:
+                f.write(f"{time.time()}, {press}, {temp}, {hum}\n")
+            time.sleep(1.5)
+
+
+def read_events(device: EnvSensorDevice, file: Optional[Path] = None):
+    with contextlib.ExitStack() as stack:
+        f = stack.enter_context(open(file, "w")) if file is not None else None
+        if f is not None:
+            f.write("Timestamp, Pressure_Pa, Temperature_C, Humidity_prh\n")
+
+        while True:
+            reply: ReplyHarpMessage = device._ser.event_q.get()
+
+            timestamp = reply.timestamp
+            pressure, temp, humidity = reply.payload
+            print(f"Timestamp: {timestamp}, Pressure: {pressure}, Temperature: {temp}, Humidity: {humidity}")
+            if f is not None:
+                f.write(f"{timestamp}, {pressure}, {temp}, {humidity}\n")
+
+
+def cli() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Environment Sensor Harp Device",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+
+    parser.add_argument("-v", "--version", action="version", version=__version__)
+    parser.add_argument("--comport", type=str, help="Serial port where the device is connected", default=None)
+    parser.add_argument("--file", type=os.path.abspath)
+    parser.add_argument("--mode", choices=["single", "continuous", "events"], default="single")
+    args = parser.parse_args(sys.argv[1:])
+
+    return args
+
+
+if __name__ == "__main__":
+
+    args = cli()
+
+    if args.comport is None:
+        ports = [port.name for port in list_ports.comports()]
+        print("Available COM ports:\n")
+        print("\n".join(ports) + "\n")
+        args.comport = port = input("Which COM port is your device on?")
+
+    device_yaml_path = Path(__file__).parents[4] / "device.yml"
+    with open(device_yaml_path, "r") as file:
+        device_yaml = yaml.safe_load(file)
+
+    config_dict = {
+        "dump_file_path": None,
+        "device_configuration": device_yaml,
+    }
+
+    device = EnvSensorDevice(args.comport, config_dict)
+    device.set_mode(DeviceMode.Active)
+
+    if args.mode == "single":
+        read_once(device)
+    elif args.mode == "continuous":
+        read_continuously(device, args.file)
+    elif args.mode == "events":
+        read_events(device, args.file)

--- a/software/python/src/harp_env_sensor/main.py
+++ b/software/python/src/harp_env_sensor/main.py
@@ -13,6 +13,60 @@ from pyharp.device import DeviceMode, Device
 
 from harp_env_sensor import EnvSensorDevice, __version__
 
+default_yaml = """
+%YAML 1.1
+---
+# yaml-language-server: $schema=https://harp-tech.org/draft-02/schema/device.json
+device: EnvironmentSensor
+whoAmI: 1405
+firmwareVersion: "0.1"
+hardwareTargets: "0.1"
+registers:
+  Pressure:
+    access: Read
+    address: 32
+    type: U32
+    description: Pressure, in Pa
+  Temperature:
+    access: Read
+    address: 33
+    type: Float
+    description: Temperature in degrees C
+  Humidity:
+    access: Read
+    address: 34
+    type: Float
+    description: Humidity, in %RH
+  SensorData:
+    access: Event
+    address: 35
+    type: Float
+    description: A periodic event will be emitted with aggregated data from all sensors.
+    length: 3
+    payloadSpec:
+      Pressure:
+        offset: 0
+        description: Pressure, in Pa
+      Temperature:
+        offset: 1
+        description: Temperature in degrees C
+      Humidity:
+        offset: 2
+        description: Humidity, in %RH
+  EnableEvents:
+    access: Write
+    address: 36
+    type: U8
+    maskType: Events
+    description: Enables (~2Hz) or disables the SensorData events
+bitMasks:
+  Events:
+    bits:
+      Disable: 0x0
+      SensorData: 0x1
+    description: Available events on the device
+"""
+
 
 def read_once(device: EnvSensorDevice) -> tuple[float, float, float]:
     pressure = device.Pressure[0]
@@ -58,6 +112,7 @@ def cli() -> argparse.Namespace:
     )
 
     parser.add_argument("-v", "--version", action="version", version=__version__)
+    parser.add_argument("--device-yaml", type=os.path.abspath, default=None)
     parser.add_argument("--comport", type=str, help="Serial port where the device is connected", default=None)
     parser.add_argument("--file", type=os.path.abspath)
     parser.add_argument("--mode", choices=["single", "continuous", "events"], default="single")
@@ -76,9 +131,14 @@ if __name__ == "__main__":
         print("\n".join(ports) + "\n")
         args.comport = port = input("Which COM port is your device on?")
 
-    device_yaml_path = Path(__file__).parents[4] / "device.yml"
-    with open(device_yaml_path, "r") as file:
-        device_yaml = yaml.safe_load(file)
+    if args.device_yaml is None:
+        device_yaml = yaml.safe_load(default_yaml)
+    else:
+        # device_yaml_path = Path(__file__).parents[4] / "device.yml"
+        with open(args.device_yaml, "r") as file:
+            device_yaml = yaml.safe_load(file)
+
+    print(device_yaml["firmwareVersion"])
 
     config_dict = {
         "dump_file_path": None,

--- a/software/python/src/harp_env_sensor/models/device.py
+++ b/software/python/src/harp_env_sensor/models/device.py
@@ -23,25 +23,29 @@ class EnvSensorDevice(Device):
         """
         self.config = config
 
-        # Create directory for dump_file if it doesn't already exist
-        dump_file_path = config["dump_file_path"]
-        if not os.path.exists(dump_file_path):
-            os.makedirs(dump_file_path)
+        dump_file_folder = config.get("dump_file_path")
+        if dump_file_folder is not None:
+            # Create directory for dump_file if it doesn't already exist
+            if not os.path.exists(dump_file_folder):
+                os.makedirs(dump_file_folder)
+            dump_file_path = dump_file_folder + dump_file
+        else:
+            dump_file_path = None
 
         self.config["device_configuration"]["whoAmI"]
 
         # Automatically read com ports if one is not given
         if not com_port:
             for port in list_ports.comports():
-                if port.pid == 24577:  # All harp devices have the same PID
+                if port.pid == 24577:  # All harp devices have the same PID ------ No they do not...
                     com_port = port.device
-                    super().__init__(com_port, dump_file_path + dump_file)
+                    super().__init__(com_port, dump_file_path)
                     if self.WHO_AM_I == self.config["device_configuration"]["whoAmI"]:
                         break
                     else:
                         self.disconnect()
         else:
-            super().__init__(com_port, dump_file_path + dump_file)
+            super().__init__(com_port, dump_file_path)
 
         logging.info(f"Connected to {com_port}, device id: {self.WHO_AM_I}")
 


### PR DESCRIPTION
Add quick python script to read from the sensor and print to terminal and a csv file. Should enable testing and characterizing of boards without using Bonsai.

It depends on the harp-serial branch of pyharp so we should probably clean that up and merge it before merging this one in, as it's pretty questionable to depend on a certain commit of a git repo...