### PR TITLE
update how PICO_SDK_PATH is searched for

### DIFF
--- a/firmware/CMakeLists.txt
+++ b/firmware/CMakeLists.txt
@@ -10,10 +10,10 @@ add_definitions(-DUSBD_PRODUCT="Environment Sensor")
 
 
 if (DEFINED PICO_SDK_PATH)
-    message("Found explicitly defined PICO_SDK_PATH: ${PICO_SDK_PATH}")
+    message("Using explicitly defined PICO_SDK_PATH.")
 elseif (DEFINED ENV{PICO_SDK_PATH} AND NOT DEFINED PICO_SDK_PATH)
     add_definitions(-DPICO_SDK_PATH="$ENV{PICO_SDK_PATH}")
-    message("Found environment variable PICO_SDK_PATH: ${PICO_SDK_PATH}")
+    message("Using environment variable PICO_SDK_PATH.")
 else()
     message(SEND_ERROR "PICO_SDK_PATH is not defined either as an environment "
 "variable or explicitly via 'cmake -DPICO_SDK_PATH=<path to pico sdk> ..'")

--- a/firmware/CMakeLists.txt
+++ b/firmware/CMakeLists.txt
@@ -8,11 +8,18 @@ add_definitions(-DGIT_HASH="${COMMIT_ID}") # Usable in source code.
 add_definitions(-DUSBD_MANUFACTURER="Allen Institute")
 add_definitions(-DUSBD_PRODUCT="Environment Sensor")
 
-if (WIN32)
-    include($ENV{PICO_SDK_PATH}/pico_sdk_init.cmake)
+
+if (DEFINED PICO_SDK_PATH)
+    message("Found explicitly defined PICO_SDK_PATH: ${PICO_SDK_PATH}")
+elseif (DEFINED ENV{PICO_SDK_PATH} AND NOT DEFINED PICO_SDK_PATH)
+    add_definitions(-DPICO_SDK_PATH="$ENV{PICO_SDK_PATH}")
+    message("Found environment variable PICO_SDK_PATH: ${PICO_SDK_PATH}")
 else()
-    include(${PICO_SDK_PATH}/pico_sdk_init.cmake)
-endif ()
+    message(SEND_ERROR "PICO_SDK_PATH is not defined either as an environment "
+"variable or explicitly via 'cmake -DPICO_SDK_PATH=<path to pico sdk> ..'")
+endif()
+include(${PICO_SDK_PATH}/pico_sdk_init.cmake)
+
 
 project(env_sensor)
 


### PR DESCRIPTION
It looks like this code was explicitly looking for `PICO_SDK_PATH` as an envrionment variable if we were on windows, but looking for an explicitly defined variable on Linux.

What we want is to support both, regardless of platform. This code looks for the explicitly-defined varialbe, then falls back to the environment variable, then produces an error with a useful message of what's missing.